### PR TITLE
Logging-config via logback including flatfile, json and console

### DIFF
--- a/sonarQuest-backend/pom.xml
+++ b/sonarQuest-backend/pom.xml
@@ -82,8 +82,19 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.7</version>
 		</dependency>
-
-	</dependencies>
+		
+        <dependency>
+    		<groupId>org.springframework.cloud</groupId>
+    		<artifactId>spring-cloud-starter-sleuth</artifactId>
+    		<version>1.3.3.RELEASE</version>
+		</dependency>
+		<dependency> 
+		    <groupId>net.logstash.logback</groupId> 
+		    <artifactId>logstash-logback-encoder</artifactId> 
+		    <version>4.11</version> 
+		</dependency>
+    </dependencies>
+    
 
 	<build>
 		<plugins>
@@ -98,6 +109,16 @@
 			</plugin>
 		</plugins>
 	</build>
-
+	
+	<repositories>
+	    <repository>
+	        <id>spring-milestones</id>
+	        <name>Spring Milestones</name>
+	        <url>https://repo.spring.io/libs-milestone</url>
+	        <snapshots>
+	            <enabled>false</enabled>
+	        </snapshots>
+	    </repository>
+	</repositories>
 
 </project>

--- a/sonarQuest-backend/src/main/resources/application.properties
+++ b/sonarQuest-backend/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.application.name=sQ
+
 ###
 #   Database Settings
 ###
@@ -16,3 +18,6 @@ spring.jpa.properties.hibernate.use_sql_comments=false
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
+
+# Make user activity transparent in the backend log (Sleuth) 
+logging.level.org.springframework.web.servlet.DispatcherServlet=DEBUG

--- a/sonarQuest-backend/src/main/resources/logback-spring.xml
+++ b/sonarQuest-backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration> <!-- Taken and adapted from here: https://github.com/spring-cloud/spring-cloud-sleuth  -->
+	<include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+	​
+	<springProperty scope="context" name="springAppName" source="spring.application.name"/>
+	
+	<property name="LOG_FILE" value="log/${springAppName}"/>​
+
+	<!-- You can override this to have a custom pattern -->
+	<property name="CONSOLE_LOG_PATTERN"
+			  value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+	
+	<!-- Appender to log to console -->
+	<appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+			<!-- Minimum logging level to be presented in the console logs-->
+			<level>DEBUG</level>
+		</filter>
+		<encoder>
+			<pattern>${CONSOLE_LOG_PATTERN}</pattern>
+			<charset>utf8</charset>
+		</encoder>
+	</appender>
+
+	<!-- Appender to log to file -->​
+	<appender name="flatfile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<file>${LOG_FILE}</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<fileNamePattern>${LOG_FILE}.%d{yyyy-MM-dd}.gz</fileNamePattern>
+			<maxHistory>7</maxHistory>
+		</rollingPolicy>
+		<encoder>
+			<pattern>${FILE_LOG_PATTERN}</pattern>
+			<charset>utf8</charset>
+		</encoder>
+	</appender>
+	​
+	<!-- Appender to log to file in a JSON format -->
+	<appender name="logstash" class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<file>${LOG_FILE}.json</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<fileNamePattern>${LOG_FILE}.json.%d{yyyy-MM-dd}.gz</fileNamePattern>
+			<maxHistory>7</maxHistory>
+		</rollingPolicy>
+		<encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+			<providers>
+				<timestamp>
+					<timeZone>UTC</timeZone>
+				</timestamp>
+				<pattern>
+					<pattern>
+						{
+						"severity": "%level",
+						"service": "${springAppName:-}",
+						"trace": "%X{X-B3-TraceId:-}",
+						"span": "%X{X-B3-SpanId:-}",
+						"parent": "%X{X-B3-ParentSpanId:-}",
+						"exportable": "%X{X-Span-Export:-}",
+						"pid": "${PID:-}",
+						"thread": "%thread",
+						"class": "%logger{40}",
+						"rest": "%message"
+						}
+					</pattern>
+				</pattern>
+			</providers>
+		</encoder>
+	</appender>
+	​
+	<root level="INFO">
+		<appender-ref ref="console"/>		
+		<appender-ref ref="logstash"/> <!-- uncomment this to have also JSON logs -->
+		<appender-ref ref="flatfile"/>
+	</root>
+</configuration>


### PR DESCRIPTION
This now includes spring sleuth request ids, hence user acivity (REST) is now also logged. This should make ex-post debugging of server-based problems easier. Also: We learn about spring sleuth here.