### PR TITLE
Grid layout for quest view

### DIFF
--- a/sonarQuest-frontend/package.json
+++ b/sonarQuest-frontend/package.json
@@ -18,6 +18,7 @@
     "@angular/common": "7.2.7",
     "@angular/compiler": "7.2.7",
     "@angular/core": "7.2.7",
+    "@angular/flex-layout": "^7.0.0-beta.24",
     "@angular/forms": "7.2.7",
     "@angular/http": "7.2.7",
     "@angular/material": "^7.3.3",

--- a/sonarQuest-frontend/src/app/app.module.ts
+++ b/sonarQuest-frontend/src/app/app.module.ts
@@ -108,6 +108,7 @@ import {LoginPageComponent} from './pages/login-page/login-page.component';
 import {MainLayoutComponent} from './layouts/main-layout/main-layout.component'
 import { SweetAlert2Module } from '@sweetalert2/ngx-sweetalert2';
 import { GamemasterSkillEditComponent } from './pages/gamemaster-page/components/gamemaster-marketplace/components/gamemaster-artefact-edit/components/gamemaster-skill-edit/gamemaster-skill-edit.component';
+import {FlexLayoutModule} from "@angular/flex-layout";
 
 // AoT requires an exported function for factories
 export function HttpLoaderFactory(http: HttpClient) {
@@ -219,6 +220,7 @@ export function HttpLoaderFactory(http: HttpClient) {
     MatProgressSpinnerModule,
     MatSelectModule,
     FormsModule,
+    FlexLayoutModule,
     ReactiveFormsModule,
     MatTabsModule,
     CovalentDataTableModule,

--- a/sonarQuest-frontend/src/app/layouts/main-layout/main-layout.component.spec.ts
+++ b/sonarQuest-frontend/src/app/layouts/main-layout/main-layout.component.spec.ts
@@ -13,6 +13,7 @@ import {UserServiceTestingModule} from "../../services/user.service.mock.module"
 import {WorldServiceTestingModule} from "../../services/world.service.mock.module";
 import {PermissionServiceTestingModule} from "../../services/permission.service.mock.module";
 import {UiDesignServiceTestingModule} from "../../services/ui-design.service.mock.module";
+import {EventServiceTestingModule} from "../../services/event.service.mock.module";
 
 describe('MainLayoutComponent', () => {
   let component: MainLayoutComponent;
@@ -37,7 +38,8 @@ describe('MainLayoutComponent', () => {
         UserServiceTestingModule,
         WorldServiceTestingModule,
         PermissionServiceTestingModule,
-        UiDesignServiceTestingModule
+        UiDesignServiceTestingModule,
+        EventServiceTestingModule
       ],
       providers: [
         TdMediaService

--- a/sonarQuest-frontend/src/app/pages/event-page/event-page.component.ts
+++ b/sonarQuest-frontend/src/app/pages/event-page/event-page.component.ts
@@ -1,19 +1,17 @@
-import { UserService } from 'app/services/user.service';
-import { ImageService } from 'app/services/image.service';
-import { EventDto } from './../../Interfaces/EventDto';
-import { UserDto } from './../../Interfaces/UserDto';
-import { Event } from '../../Interfaces/Event';
-import { ViewChildren, QueryList, ElementRef, Component, OnInit } from '@angular/core';
-import { EventService } from '../../services/event.service';
-import { WebsocketService } from 'app/services/websocket.service';
-import { Subject, ReplaySubject } from 'rxjs';
+import {EventDto} from '../../Interfaces/EventDto';
+import {UserDto} from '../../Interfaces/UserDto';
+import {Event} from '../../Interfaces/Event';
+import {AfterViewInit, Component, ElementRef, OnInit, QueryList, ViewChildren} from '@angular/core';
+import {EventService} from '../../services/event.service';
+import {WebsocketService} from 'app/services/websocket.service';
+import {ReplaySubject, Subject} from 'rxjs';
 
 @Component({
   selector: 'app-event-page',
   templateUrl: './event-page.component.html',
   styleUrls: ['./event-page.component.css']
 })
-export class EventPageComponent implements OnInit {
+export class EventPageComponent implements OnInit, AfterViewInit {
 
   private eventDtosSubject: Subject<EventDto[]> = new ReplaySubject(1); 
   public  eventDtos$ = this.eventDtosSubject.asObservable();
@@ -34,11 +32,11 @@ export class EventPageComponent implements OnInit {
     private websocketService: WebsocketService
   ) {
       this.eventService.eventDtos$.subscribe(eventDtos => { 
-        this.eventDtos = eventDtos
-      })
+        this.eventDtos = eventDtos;
+      });
       this.eventService.userDtos$.subscribe(userDtos => { 
-        this.userDtos = userDtos
-      })
+        this.userDtos = userDtos;
+      });
   }
 
   ngOnInit() {
@@ -49,11 +47,8 @@ export class EventPageComponent implements OnInit {
     
     this.commentDivs.changes.subscribe(() => {
       if (this.commentDivs && this.commentDivs.last) {
-        //this.commentDivs.last.nativeElement.focus();
         if (this.commentDivs.last.nativeElement.children) {
-          console.log(this.commentDivs.last.nativeElement);
-          console.log(this.commentDivs.last.nativeElement.lastChild);
-          this.commentDivs.last.nativeElement.lastChild.style.cssText = ("padding-bottom: 50px")
+          this.commentDivs.last.nativeElement.lastChild.style.cssText = ("padding-bottom: 50px");
           this.commentDivs.last.nativeElement.lastChild.focus();
           this.commentDivs.last.nativeElement.lastChild.style.cssText = ("padding-bottom: 0px")
         }
@@ -68,12 +63,12 @@ export class EventPageComponent implements OnInit {
       return true;
     } else if (this.eventDtos[0].id === event.id) {
       // When this is the first Event in the List show Date
-      this.previousEvent = event
+      this.previousEvent = event;
       return true;
     } else if ((new Date(this.previousEvent.timestamp).getDate() < new Date(event.timestamp).getDate()) || 
               (new Date(this.previousEvent.timestamp).getMonth() < new Date(event.timestamp).getMonth()) ||
               (new Date(this.previousEvent.timestamp).getFullYear() < new Date(event.timestamp).getFullYear())) {
-      this.previousEvent = event
+      this.previousEvent = event;
       return true;
     } else {
       this.previousEvent = event;
@@ -119,8 +114,8 @@ export class EventPageComponent implements OnInit {
       if ( e.userId == userDto.id) {
         name = userDto.username;
       }
-    })
-    return name
+    });
+    return name;
   }
 
 }

--- a/sonarQuest-frontend/src/app/pages/gamemaster-page/components/gamemaster-marketplace/components/gamemaster-artefact-edit/components/gamemaster-skill-edit/gamemaster-skill-edit.component.spec.ts
+++ b/sonarQuest-frontend/src/app/pages/gamemaster-page/components/gamemaster-marketplace/components/gamemaster-artefact-edit/components/gamemaster-skill-edit/gamemaster-skill-edit.component.spec.ts
@@ -1,14 +1,60 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GamemasterSkillEditComponent } from './gamemaster-skill-edit.component';
+import {TranslateTestingModule} from "../../../../../../../../services/translate.service.mock.module";
+import {BrowserModule} from "@angular/platform-browser";
+import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
+import {RouterTestingModule} from "@angular/router/testing";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule, MatDialogRef,
+  MatDividerModule,
+  MatFormFieldModule,
+  MatIconModule, MatInputModule, MatSelectModule,
+  MatToolbarModule,
+  MatTooltipModule
+} from "@angular/material";
+import {CovalentDataTableModule} from "@covalent/core";
+import {ArtefactServiceTestingModule} from "../../../../../../../../services/artefact.service.mock.module";
+import {SkillServiceTestingModule} from "../../../../../../../../services/skill.service.mock.module";
 
 describe('GamemasterSkillEditComponent', () => {
   let component: GamemasterSkillEditComponent;
   let fixture: ComponentFixture<GamemasterSkillEditComponent>;
 
+  const data = {
+    minLevel: {
+      levelNumber: 1
+    }
+  };
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ GamemasterSkillEditComponent ]
+      declarations: [ GamemasterSkillEditComponent ],
+      imports: [
+        BrowserModule,
+        BrowserAnimationsModule,
+        RouterTestingModule,
+        FormsModule,
+        ReactiveFormsModule,
+        TranslateTestingModule,
+        MatTooltipModule,
+        MatIconModule,
+        MatDialogModule,
+        MatSelectModule,
+        MatDividerModule,
+        MatToolbarModule,
+        MatFormFieldModule,
+        MatInputModule,
+        CovalentDataTableModule,
+        ArtefactServiceTestingModule,
+        SkillServiceTestingModule
+      ],
+      providers: [
+        {provide: MAT_DIALOG_DATA, useValue: data},
+        {provide: MatDialogRef, useValue: {}}
+      ]
     })
     .compileComponents();
   }));

--- a/sonarQuest-frontend/src/app/pages/gamemaster-page/components/gamemaster-marketplace/components/gamemaster-artefact-edit/gamemaster-artefact-edit.component.spec.ts
+++ b/sonarQuest-frontend/src/app/pages/gamemaster-page/components/gamemaster-marketplace/components/gamemaster-artefact-edit/gamemaster-artefact-edit.component.spec.ts
@@ -8,6 +8,7 @@ import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {TranslateTestingModule} from "../../../../../../services/translate.service.mock.module";
 import {
   MAT_DIALOG_DATA,
+  MatCheckboxModule,
   MatDialogModule,
   MatDialogRef,
   MatDividerModule,
@@ -46,6 +47,7 @@ describe('GamemasterArtefactEditComponent', () => {
         MatDialogModule,
         MatDividerModule,
         MatToolbarModule,
+        MatCheckboxModule,
         MatFormFieldModule,
         MatInputModule,
         CovalentDataTableModule,

--- a/sonarQuest-frontend/src/app/pages/quest-page/components/available-quests/available-quests.component.css
+++ b/sonarQuest-frontend/src/app/pages/quest-page/components/available-quests/available-quests.component.css
@@ -3,33 +3,5 @@
   background-repeat: no-repeat;
   background-position: top;
   background-blend-mode: difference;
-  width: 100%;
 }
 
-.quest-container {
-  display: grid;
-  grid-column-gap: 10px;
-}
-
-@media only screen and (min-width: 320px) and (max-width: 600px){
-  .quest-container {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media only screen and (min-width: 601px) and (max-width: 980px){
-  .quest-container {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-@media only screen and (min-device-width: 981px) and (max-width: 1600px){
-  .quest-container {
-    grid-template-columns: 1fr 1fr 1fr;
-  }
-}
-
-@media only screen and (min-device-width: 1601px){
-  .quest-container {
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-  }
-}

--- a/sonarQuest-frontend/src/app/pages/quest-page/components/available-quests/available-quests.component.html
+++ b/sonarQuest-frontend/src/app/pages/quest-page/components/available-quests/available-quests.component.html
@@ -42,8 +42,9 @@
         {{"QUEST_PAGE.AVAILABLE_QUESTS_FOR_WORLD"| translate}} <strong>{{currentWorld?.name}}</strong>
       </h2>
     </div>
-    <div *ngFor="let quest of availableQuests" class="quest-container">
-      <mat-card id="questcard">
+    <div fxLayout="row wrap" fxLayout.lt-sm="column" fxLayoutGap="32px" fxLayoutAlign="flex-start">
+      <div *ngFor="let quest of availableQuests" fxFlex="0 1 calc(33.3% -32px)" fxFlex.lt-lg="0 1 calc(50% - 32px)" fxFlex.lt-md="100%">
+        <mat-card id="questcard">
           <mat-card-header>
             <img mat-card-avatar [src]="quest.image" alt="Image of the Quest {{ quest.title }}">
             <mat-card-title>
@@ -59,23 +60,25 @@
               <br />
               {{"TABLE.COLUMNS.STATUS" | translate}}: {{quest.status}}
               <br />
-              {{"TABLE.COLUMNS.CREATORNAME" | translate}}: {{quest.creatorName}}     
+              {{"TABLE.COLUMNS.CREATORNAME" | translate}}: {{quest.creatorName}}
             </div>
-            
+
           </mat-card-content>
           <mat-card-actions>
             <div align="right">
               <button mat-icon-button (click)="viewQuest(quest)" [matTooltip]="'QUEST_PAGE.SHOW_QUEST' | translate"
-                [matTooltipClass]="'tooltipMultiline'" matTooltipPosition="below">
+                      [matTooltipClass]="'tooltipMultiline'" matTooltipPosition="below">
                 <i class="ra ra-quill-ink ra-2x"></i>
               </button>
               <button mat-icon-button (click)="participateInQuest(quest)" [matTooltip]="'QUEST_PAGE.JOIN_QUEST' | translate"
-                [matTooltipClass]="'tooltipMultiline'" matTooltipPosition="below">
+                      [matTooltipClass]="'tooltipMultiline'" matTooltipPosition="below">
                 <i class="ra ra-sword ra-2x"></i>
               </button>
             </div>
           </mat-card-actions>
         </mat-card>
       </div>
+      </div>
+
   </mat-card-content>
 </mat-card>

--- a/sonarQuest-frontend/src/app/pages/quest-page/components/participated-quests/participated-quests.component.css
+++ b/sonarQuest-frontend/src/app/pages/quest-page/components/participated-quests/participated-quests.component.css
@@ -5,31 +5,3 @@
   background-blend-mode: difference;
   width: 100%;
 }
-
-.quest-container {
-  display: grid;
-  grid-column-gap: 10px;
-}
-
-@media only screen and (min-width: 320px) and (max-width: 600px){
-  .quest-container {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media only screen and (min-width: 601px) and (max-width: 980px){
-  .quest-container {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-@media only screen and (min-device-width: 981px) and (max-width: 1600px){
-  .quest-container {
-    grid-template-columns: 1fr 1fr 1fr;
-  }
-}
-
-@media only screen and (min-device-width: 1601px){
-  .quest-container {
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-  }
-}

--- a/sonarQuest-frontend/src/app/pages/quest-page/components/participated-quests/participated-quests.component.html
+++ b/sonarQuest-frontend/src/app/pages/quest-page/components/participated-quests/participated-quests.component.html
@@ -43,40 +43,41 @@
         {{"QUEST_PAGE.MY_QUESTS_FOR_WORLD"| translate}} <strong>{{currentWorld?.name}}</strong>
       </h2>
     </div>
-        <div *ngFor="let quest of participatedQuests" class="quest-container">
-
-
-          <mat-card id="questcard">
-            <mat-card-header>
-              <img mat-card-avatar [src]="quest.image">
-              <mat-card-title>
-                <h3>{{quest.title}}</h3>
-              </mat-card-title>
-              <mat-card-subtitle>{{quest.adventure?.title}}</mat-card-subtitle>
-            </mat-card-header>
-            <mat-card-content>
-              <div>
-                {{"TABLE.COLUMNS.GOLD" | translate}}: {{quest.gold}}
-                <br />
-                {{"TABLE.COLUMNS.XP" | translate}}: {{quest.xp}}
-                <br />
-                {{"TABLE.COLUMNS.STATUS" | translate}}: {{quest.status}}
-                <br />
-                {{"TABLE.COLUMNS.CREATORNAME" | translate}}: {{quest.creatorName}}                
-                <button mat-icon-button (click)="solveDummy(quest)" [matTooltip]="'SOLVE'"
-                  [matTooltipClass]="'tooltipMultiline'" matTooltipPosition="below">
-                  SOLVE
-                </button>
-              </div>
-            </mat-card-content>
-            <mat-card-actions>
-              <div align="right">
-                <button mat-icon-button (click)="viewQuest(quest)" [matTooltip]="'QUEST_PAGE.SHOW_QUEST' | translate"
-                  [matTooltipClass]="'tooltipMultiline'" matTooltipPosition="below">
-                  <i class="ra ra-quill-ink ra-2x"></i>
-                </button>
-              </div>
-            </mat-card-actions>
-          </mat-card>
+    <div fxLayout="row wrap" fxLayout.lt-sm="column" fxLayoutGap="32px" fxLayoutAlign="flex-start">
+      <div *ngFor="let quest of participatedQuests" fxFlex="0 1 calc(33.3% -32px)" fxFlex.lt-lg="0 1 calc(50% - 32px)" fxFlex.lt-md="100%">
+            <mat-card id="questcard">
+              <mat-card-header>
+                <img mat-card-avatar [src]="quest.image">
+                <mat-card-title>
+                  <h3>{{quest.title}}</h3>
+                </mat-card-title>
+                <mat-card-subtitle>{{quest.adventure?.title}}</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <div>
+                  {{"TABLE.COLUMNS.GOLD" | translate}}: {{quest.gold}}
+                  <br />
+                  {{"TABLE.COLUMNS.XP" | translate}}: {{quest.xp}}
+                  <br />
+                  {{"TABLE.COLUMNS.STATUS" | translate}}: {{quest.status}}
+                  <br />
+                  {{"TABLE.COLUMNS.CREATORNAME" | translate}}: {{quest.creatorName}}
+                  <button mat-icon-button (click)="solveDummy(quest)" [matTooltip]="'SOLVE'"
+                          [matTooltipClass]="'tooltipMultiline'" matTooltipPosition="below">
+                    SOLVE
+                  </button>
+                </div>
+              </mat-card-content>
+              <mat-card-actions>
+                <div align="right">
+                  <button mat-icon-button (click)="viewQuest(quest)" [matTooltip]="'QUEST_PAGE.SHOW_QUEST' | translate"
+                          [matTooltipClass]="'tooltipMultiline'" matTooltipPosition="below">
+                    <i class="ra ra-quill-ink ra-2x"></i>
+                  </button>
+                </div>
+              </mat-card-actions>
+            </mat-card>
+          </div>
         </div>
+
   </mat-card-content>

--- a/sonarQuest-frontend/src/app/services/event.service.mock.module.ts
+++ b/sonarQuest-frontend/src/app/services/event.service.mock.module.ts
@@ -2,11 +2,17 @@ import {Injectable, NgModule} from '@angular/core';
 import {EventService} from "./event.service";
 import {Observable} from "rxjs";
 import {Event} from "../Interfaces/Event";
+import {EventDto} from "../Interfaces/EventDto";
+import {UserDto} from "../Interfaces/UserDto";
+import {EventUserDto} from "../Interfaces/EventUserDto";
 
 @Injectable()
 export class EventServiceMock {
 
   public  events$ = new Observable<Event[]>();
+  public  eventUserDto$ = new Observable<EventUserDto>();
+  public  eventDtos$ = new Observable<EventDto[]>();
+  public  userDtos$  = new Observable<UserDto[]>();
 
   getEventsOfCurrentWorld(): Observable<Event[]>{
     return new Observable<Event[]>();


### PR DESCRIPTION
**Added Features**
Layout improvements
- The quest view for participated and available quests is now fully responsive
- The quest view for participated and available quests uses now the whole available space. It know uses a 1 to 3 column layout, which depends on the view size of the device


**Fixes**
- Fixed the not working frontend tests by adding missing dependencies
- Extended the event mock service to reflect the changes at the real event service

**Solved Issues**
none.

**Added dependecies**
- @angular/flex