### PR TITLE
Adding attribute organization to SonarConfig - organizationKey is req…

### DIFF
--- a/sonarQuest-backend/src/main/java/com/viadee/sonarquest/entities/SonarConfig.java
+++ b/sonarQuest-backend/src/main/java/com/viadee/sonarquest/entities/SonarConfig.java
@@ -33,7 +33,10 @@ public class SonarConfig {
 
     @Column(name = "http_basic_auth_password")
     private String httpBasicAuthPassword;
-
+    
+    @Column(name="organization")
+    private String organization;
+    
     public Long getId() {
         return id;
     }
@@ -77,4 +80,12 @@ public class SonarConfig {
     public boolean hasHttpBasicAuth() {
         return StringUtils.isNotBlank(httpBasicAuthUsername) && StringUtils.isNotBlank(httpBasicAuthPassword);
     }
+
+	public String getOrganization() {
+		return organization;
+	}
+
+	public void setOrganization(String organization) {
+		this.organization = organization;
+	}
 }

--- a/sonarQuest-backend/src/main/java/com/viadee/sonarquest/externalressources/SonarQubeApiCall.java
+++ b/sonarQuest-backend/src/main/java/com/viadee/sonarquest/externalressources/SonarQubeApiCall.java
@@ -71,6 +71,14 @@ public class SonarQubeApiCall {
         appendSearchParameter("componentKeys=" + projectKey);
         return this;
     }
+    
+    /**
+     * Appends the parameter "organization" with the value organization to the sonarQubeRestApiCall.
+     */
+    public SonarQubeApiCall withOrganization(String organization) {
+        appendSearchParameter("organization=" + organization);
+        return this;
+    }
 
     /**
      * Appends the parameter "types" with the value issueType to the sonarQubeRestApiCall.

--- a/sonarQuest-backend/src/main/java/com/viadee/sonarquest/services/ExternalRessourceService.java
+++ b/sonarQuest-backend/src/main/java/com/viadee/sonarquest/services/ExternalRessourceService.java
@@ -200,6 +200,7 @@ public class ExternalRessourceService {
         SonarQubeApiCall sonarQubeApiCall = SonarQubeApiCall
                 .onServer(sonarConfig.getSonarServerUrl())
                 .searchComponents(SonarQubeComponentQualifier.TRK)
+                .withOrganization(sonarConfig.getOrganization())
                 .pageSize(maxNumberOfIssuesOnPage)
                 .pageIndex(pageIndex)
                 .build();

--- a/sonarQuest-backend/src/main/java/com/viadee/sonarquest/services/SonarConfigService.java
+++ b/sonarQuest-backend/src/main/java/com/viadee/sonarquest/services/SonarConfigService.java
@@ -42,6 +42,7 @@ public class SonarConfigService {
 
     private SonarConfig updateCurrentConfig(final SonarConfig config, final SonarConfig currentConfig) {
         currentConfig.setName(config.getName());
+        currentConfig.setOrganization(config.getOrganization());
         currentConfig.setSonarServerUrl(configUrlWithoutSlash(config.getSonarServerUrl()));
         currentConfig.setHttpBasicAuthUsername(config.getHttpBasicAuthUsername());
         currentConfig.setHttpBasicAuthPassword(config.getHttpBasicAuthPassword());

--- a/sonarQuest-backend/src/main/resources/db/data/V0_0_2__data.sql
+++ b/sonarQuest-backend/src/main/resources/db/data/V0_0_2__data.sql
@@ -1,5 +1,5 @@
-INSERT INTO Sonar_Config (name, sonar_server_url) VALUES
-  ('World of Sonar Quest', 'https://sonarcloud.io');
+INSERT INTO Sonar_Config (name, sonar_server_url, organization) VALUES
+  ('World of Sonar Quest', 'https://sonarcloud.io', 'default');
 
 INSERT INTO SQLevel (sqlevel, min_xp, max_xp) VALUES
 	(1,1,9),

--- a/sonarQuest-backend/src/main/resources/db/schema/V0_0_1__schema.sql
+++ b/sonarQuest-backend/src/main/resources/db/schema/V0_0_1__schema.sql
@@ -3,7 +3,8 @@ CREATE TABLE Sonar_Config (
   name             VARCHAR(128),
   sonar_server_url VARCHAR(128),
   http_basic_auth_username VARCHAR(128),
-  http_basic_auth_password VARCHAR(128)
+  http_basic_auth_password VARCHAR(128),
+  organization		VARCHAR(128)
 );
 
 CREATE TABLE SQLevel (

--- a/sonarQuest-frontend/src/app/Interfaces/SonarQubeConfig.ts
+++ b/sonarQuest-frontend/src/app/Interfaces/SonarQubeConfig.ts
@@ -3,4 +3,5 @@ export interface SonarQubeConfig {
   sonarServerUrl: string;
   httpBasicAuthUsername?: string;
   httpBasicAuthPassword?: string;
+  organization: string;
 }

--- a/sonarQuest-frontend/src/app/pages/admin-page/components/admin-sonar-qube/admin-sonar-qube.component.html
+++ b/sonarQuest-frontend/src/app/pages/admin-page/components/admin-sonar-qube/admin-sonar-qube.component.html
@@ -13,6 +13,12 @@
 
   <div flex>
     <mat-form-field>
+      <input matInput placeholder="Organization key" [(ngModel)]="organization">
+    </mat-form-field>
+  </div>
+
+  <div flex>
+    <mat-form-field>
       <input matInput placeholder="Http Basic Auth Username" [(ngModel)]="httpBasicAuthUsername">
     </mat-form-field>
   </div>

--- a/sonarQuest-frontend/src/app/pages/admin-page/components/admin-sonar-qube/admin-sonar-qube.component.ts
+++ b/sonarQuest-frontend/src/app/pages/admin-page/components/admin-sonar-qube/admin-sonar-qube.component.ts
@@ -24,6 +24,8 @@ export class AdminSonarQubeComponent implements OnInit {
 
   sonarConfig: SonarQubeConfig;
 
+  organization: string;
+
   constructor(private sonarQubeService: SonarQubeService,
               private worldService: WorldService,
               private snackBar: MatSnackBar,
@@ -46,6 +48,7 @@ export class AdminSonarQubeComponent implements OnInit {
     this.sonarQubeUrl = this.sonarConfig.sonarServerUrl;
     this.httpBasicAuthUsername = this.sonarConfig.httpBasicAuthUsername;
     this.httpBasicAuthPassword = this.sonarConfig.httpBasicAuthPassword;
+    this.organization = this.sonarConfig.organization;
   }
 
   checkSonarQubeUrl() {
@@ -55,7 +58,8 @@ export class AdminSonarQubeComponent implements OnInit {
       name: this.configName,
       sonarServerUrl: this.sonarQubeUrl,
       httpBasicAuthPassword: this.httpBasicAuthPassword,
-      httpBasicAuthUsername: this.httpBasicAuthUsername
+      httpBasicAuthUsername: this.httpBasicAuthUsername,
+      organization: this.organization
     })
       .then(available => {
         if (available) {
@@ -88,7 +92,8 @@ export class AdminSonarQubeComponent implements OnInit {
       name: this.configName,
       sonarServerUrl: this.sonarQubeUrl,
       httpBasicAuthUsername: this.httpBasicAuthUsername,
-      httpBasicAuthPassword: this.httpBasicAuthPassword
+      httpBasicAuthPassword: this.httpBasicAuthPassword,
+      organization: this.organization
     };
     this.sonarQubeService.checkSonarQubeURL(config).then((available) => {
       if (!available) {


### PR DESCRIPTION
Added attribute 'organization' to SonarConfig because the parameter is now required for api call 'https://sonarcloud.io/web_api/api/components'.

Is from Issue 'SonarQube Api Call https://sonarcloud.io/api/components/search to generate Worlds no longer works' #259 .


Requirements for pull requests

Please refer to our Contribution Guide. What we would like to know from you:
* what did you change?
* why did you change it? why should it be in master?
** fixes
** features
** other benefits
* which issues are solved by this?